### PR TITLE
Cleaned up cmake_modules and eigen

### DIFF
--- a/cob_3d_features/CMakeLists.txt
+++ b/cob_3d_features/CMakeLists.txt
@@ -12,7 +12,6 @@ set(catkin_RUN_PACKAGES
 
 set(catkin_BUILD_PACKAGES 
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 
 ## Find catkin macros and libraries

--- a/cob_3d_features/package.xml
+++ b/cob_3d_features/package.xml
@@ -17,7 +17,6 @@
 	<buildtool_depend>catkin</buildtool_depend>
 
 	<depend>boost</depend>
-	<depend>cmake_modules</depend>
 	<depend>cob_3d_mapping_common</depend>
 	<depend>cob_3d_mapping_msgs</depend>
 	<depend>cob_3d_visualization</depend>

--- a/cob_3d_fov_segmentation/CMakeLists.txt
+++ b/cob_3d_fov_segmentation/CMakeLists.txt
@@ -9,7 +9,6 @@ set(catkin_RUN_PACKAGES
 
 set(catkin_BUILD_PACKAGES
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 
 ## Find catkin macros and libraries

--- a/cob_3d_fov_segmentation/package.xml
+++ b/cob_3d_fov_segmentation/package.xml
@@ -16,7 +16,6 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
-	<depend>cmake_modules</depend>
 	<depend>cob_3d_mapping_common</depend>
 	<depend>dynamic_reconfigure</depend>
 	<depend>tf_conversions</depend>

--- a/cob_3d_mapping_common/CMakeLists.txt
+++ b/cob_3d_mapping_common/CMakeLists.txt
@@ -12,7 +12,6 @@ set(catkin_RUN_PACKAGES
 
 set(catkin_BUILD_PACKAGES
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 
 ## Find catkin macros and libraries

--- a/cob_3d_mapping_common/package.xml
+++ b/cob_3d_mapping_common/package.xml
@@ -16,7 +16,6 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
-	<depend>cmake_modules</depend>
 	<depend>cob_3d_mapping_msgs</depend>
 	<depend>eigen_conversions</depend>
 	<depend>libgpc</depend>

--- a/cob_3d_mapping_geometry_map/CMakeLists.txt
+++ b/cob_3d_mapping_geometry_map/CMakeLists.txt
@@ -12,9 +12,8 @@ set(catkin_RUN_PACKAGES
 	tf_conversions
 )
 
-set(catkin_BUILD_PACKAGES 
+set(catkin_BUILD_PACKAGES
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 
 ## Find catkin macros and libraries

--- a/cob_3d_mapping_geometry_map/package.xml
+++ b/cob_3d_mapping_geometry_map/package.xml
@@ -16,7 +16,6 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
-	<depend>cmake_modules</depend>
 	<depend>cob_3d_mapping_common</depend>
 	<depend>cob_3d_mapping_msgs</depend>
 	<depend>dynamic_reconfigure</depend>

--- a/cob_3d_mapping_semantics/CMakeLists.txt
+++ b/cob_3d_mapping_semantics/CMakeLists.txt
@@ -14,7 +14,6 @@ set(catkin_RUN_PACKAGES
 
 set(catkin_BUILD_PACKAGES 
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 
 

--- a/cob_3d_mapping_semantics/package.xml
+++ b/cob_3d_mapping_semantics/package.xml
@@ -16,7 +16,6 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
-	<depend>cmake_modules</depend>
 	<depend>cob_3d_mapping_common</depend>
 	<depend>cob_3d_mapping_msgs</depend>
 	<depend>cob_3d_visualization</depend>

--- a/cob_3d_mapping_slam/CMakeLists.txt
+++ b/cob_3d_mapping_slam/CMakeLists.txt
@@ -10,9 +10,8 @@ set(catkin_RUN_PACKAGES
 	tf_conversions
 )
 
-set(catkin_BUILD_PACKAGES 
+set(catkin_BUILD_PACKAGES
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 
 ## Find catkin macros and libraries
@@ -25,6 +24,23 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(CGAL REQUIRED)
 #find_package(nurbs++ REQUIRED)
 ##TODO: check for SSE
+
+find_package(Eigen3)
+if(NOT EIGEN3_FOUND)
+	# Fallback to cmake_modules
+	find_package(cmake_modules REQUIRED)
+	find_package(Eigen REQUIRED)
+	set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+	set(EIGEN3_LIBRARIES ${EIGEN_LIBRARIES})  # Not strictly necessary as Eigen is head only
+	set(EIGEN3_DEFINITIONS ${EIGEN_DEFINITIONS})
+	set(EIGEN3_DEPENDS Eigen)
+	# Possibly map additional variables to the EIGEN3_ prefix.
+else()
+	set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+	set(EIGEN3_DEPENDS Eigen3)
+endif()
+add_definitions(${EIGEN3_DEFINITIONS})
+# do not forget: include_directories(${EIGEN3_INCLUDE_DIRS})
 
 
 ###################################
@@ -48,7 +64,6 @@ catkin_package(
 )
 
 
-
 ###########
 ## Build ##
 ###########
@@ -60,6 +75,7 @@ catkin_package(
 #	common/include
 #	ros/include
 #	${CGAL_INCLUDE_DIR}
+#	${EIGEN3_INCLUDE_DIRS}
 #)
 
 

--- a/cob_3d_mapping_slam/package.xml
+++ b/cob_3d_mapping_slam/package.xml
@@ -20,7 +20,7 @@
 
 	<!--depend>arm_navigation_msgs</depend-->
 	<depend>cgal</depend>
-	<depend>cgal-qt5-dev</depend>
+	<!--depend>cgal-qt5-dev</depend-->
 	<depend>cob_3d_mapping_msgs</depend>
 	<depend>nav_msgs</depend>
 	<!--depend>nurbs++</depend-->

--- a/cob_3d_mapping_slam/package.xml
+++ b/cob_3d_mapping_slam/package.xml
@@ -16,9 +16,11 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
+	<build_depend>cmake_modules</build_depend>
+
 	<!--depend>arm_navigation_msgs</depend-->
 	<depend>cgal</depend>
-	<depend>cmake_modules</depend>
+	<depend>cgal-qt5-dev</depend>
 	<depend>cob_3d_mapping_msgs</depend>
 	<depend>nav_msgs</depend>
 	<!--depend>nurbs++</depend-->

--- a/cob_3d_mapping_tools/CMakeLists.txt
+++ b/cob_3d_mapping_tools/CMakeLists.txt
@@ -12,9 +12,8 @@ set(catkin_RUN_PACKAGES
 	sensor_msgs
 )
 
-set(catkin_BUILD_PACKAGES 
+set(catkin_BUILD_PACKAGES
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 
 ## Find catkin macros and libraries
@@ -27,7 +26,6 @@ find_package(catkin REQUIRED COMPONENTS
 #find_package(TinyXML REQUIRED)
 find_package(VTK REQUIRED COMPONENTS vtkCommon vtkFiltering vtkRendering)
 find_package(Boost REQUIRED COMPONENTS filesystem program_options signals system)
-find_package(Eigen REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(PCL REQUIRED)
 find_package(wxWidgets REQUIRED)
@@ -51,7 +49,6 @@ catkin_package(
 		${catkin_RUN_PACKAGES}
 	DEPENDS
 		Boost
-		Eigen
 		PCL
 )
 
@@ -68,7 +65,6 @@ include_directories(
 	${catkin_INCLUDE_DIRS}
 	${VTK_INCLUDE_DIRS}
 	${Boost_INCLUDE_DIRS}
-	${Eigen_INCLUDE_DIRS}
 	${OpenCV_INCLUDE_DIRS}
 	${wxWidgets_INCLUDE_DIRS}
 )

--- a/cob_3d_mapping_tools/package.xml
+++ b/cob_3d_mapping_tools/package.xml
@@ -17,12 +17,10 @@
 	<buildtool_depend>catkin</buildtool_depend>
 
 	<depend>boost</depend>
-	<depend>cmake_modules</depend>
 	<depend>cob_3d_features</depend>
 	<depend>cob_3d_fov_segmentation</depend>
 	<depend>cob_3d_mapping_common</depend>
 	<depend>cob_3d_segmentation</depend>
-	<depend>eigen</depend>
 	<depend>libopencv-dev</depend>
 	<depend>libpcl-all-dev</depend>
 	<depend>libvtk</depend>

--- a/cob_3d_registration/CMakeLists.txt
+++ b/cob_3d_registration/CMakeLists.txt
@@ -17,7 +17,6 @@ set(catkin_RUN_PACKAGES
 set(catkin_BUILD_PACKAGES 
 	${catkin_RUN_PACKAGES}
 	message_generation
-	cmake_modules
 )
 
 ## Find catkin macros and libraries
@@ -31,7 +30,6 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(VTK REQUIRED COMPONENTS vtkCommon)
 #find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(OpenCV REQUIRED)
-find_package(Eigen REQUIRED)
 #find_package(PCL REQUIRED)
 #TODO: check for SSE
 
@@ -78,7 +76,6 @@ catkin_package(
 	DEPENDS
 		VTK
 		OpenCV
-		Eigen
 #		PCL
 )
 
@@ -95,7 +92,6 @@ include_directories(
 	${catkin_INCLUDE_DIRS}
 	${VTK_INCLUDE_DIRS}
 	${OpenCV_INCLUDE_DIRS}
-	${Eigen_INCLUDE_DIRS}
 	${PCL_INCLUDE_DIRS}
 )
 

--- a/cob_3d_registration/package.xml
+++ b/cob_3d_registration/package.xml
@@ -17,12 +17,10 @@
 	<buildtool_depend>catkin</buildtool_depend>
 
 	<!--depend>boost</depend-->
-	<depend>cmake_modules</depend>
 	<depend>cob_3d_features</depend>
 	<depend>cob_3d_mapping_common</depend>
 	<depend>cv_bridge</depend>
 	<!--depend>dynamic_reconfigure</depend-->
-	<depend>eigen</depend>
 	<depend>libvtk</depend>
 	<depend>message_generation</depend>
 	<depend>nav_msgs</depend>

--- a/cob_3d_segmentation/CMakeLists.txt
+++ b/cob_3d_segmentation/CMakeLists.txt
@@ -17,9 +17,8 @@ set(catkin_RUN_PACKAGES
 	roscpp
 )
 
-set(catkin_BUILD_PACKAGES 
+set(catkin_BUILD_PACKAGES
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 	message_generation
 )
 

--- a/cob_3d_segmentation/package.xml
+++ b/cob_3d_segmentation/package.xml
@@ -19,7 +19,6 @@
 	<depend>actionlib</depend>
 	<depend>actionlib_msgs</depend>
 	<depend>boost</depend>
-	<depend>cmake_modules</depend>
 	<depend>cob_3d_features</depend>
 	<depend>cob_3d_mapping_common</depend>
 	<depend>cob_3d_mapping_filters</depend>

--- a/cob_3d_transform_nodes/package.xml
+++ b/cob_3d_transform_nodes/package.xml
@@ -16,7 +16,6 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
-	<depend>cmake_modules</depend>
 	<depend>cob_3d_mapping_common</depend>
 	<depend>cob_3d_mapping_msgs</depend>
 	<depend>pcl_ros</depend>

--- a/cob_3d_visualization/CMakeLists.txt
+++ b/cob_3d_visualization/CMakeLists.txt
@@ -11,7 +11,6 @@ set(catkin_RUN_PACKAGES
 
 set(catkin_BUILD_PACKAGES 
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 
 ## Find catkin macros and libraries

--- a/cob_3d_visualization/package.xml
+++ b/cob_3d_visualization/package.xml
@@ -15,8 +15,7 @@
 	<url>http://wiki.ros.org/cob_3d_visualization</url>
 
 	<buildtool_depend>catkin</buildtool_depend>
-
-	<depend>cmake_modules</depend>
+	
 	<depend>cob_3d_mapping_common</depend>
 	<depend>cob_3d_mapping_msgs</depend>
 	<depend>eigen_conversions</depend>

--- a/cob_keyframe_detector/CMakeLists.txt
+++ b/cob_keyframe_detector/CMakeLists.txt
@@ -10,9 +10,8 @@ set(catkin_RUN_PACKAGES
 	tf_conversions
 )
 
-set(catkin_BUILD_PACKAGES 
+set(catkin_BUILD_PACKAGES
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/cob_keyframe_detector/package.xml
+++ b/cob_keyframe_detector/package.xml
@@ -16,7 +16,6 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
-	<depend>cmake_modules</depend>
 	<depend>dynamic_reconfigure</depend>
 	<depend>roscpp</depend>
 	<depend>sensor_msgs</depend>

--- a/cob_table_object_cluster/CMakeLists.txt
+++ b/cob_table_object_cluster/CMakeLists.txt
@@ -17,9 +17,8 @@ set(catkin_RUN_PACKAGES
 	tf_conversions
 )
 
-set(catkin_BUILD_PACKAGES 
+set(catkin_BUILD_PACKAGES
 	${catkin_RUN_PACKAGES}
-	cmake_modules
 )
 
 ## Find catkin macros and libraries


### PR DESCRIPTION
@ipa-fxm are you satisfied with this cleanup?

One question: In cob_3d_mapping_slam I need one additional dependency for Kinetic (<depend>cgal-qt5-dev</depend>), but this does not exist in indigo. Can I still have a dual distro setup or would I need to split off a kinetic_dev branch?